### PR TITLE
docs: fix simple typo, lenght -> length

### DIFF
--- a/大二下/物联网导论/QRCode/decode/QRCode/src/qrcode/QRCode.cpp
+++ b/大二下/物联网导论/QRCode/decode/QRCode/src/qrcode/QRCode.cpp
@@ -485,7 +485,7 @@ string QRCode::EncodeData(void)
 
     res += terminator;
 
-    // Pad 0 to the right of the string to make it lenght multiple of 8
+    // Pad 0 to the right of the string to make it length multiple of 8
     while (strlen(res.c_str()) % 8 != 0)
         res += "0";
 

--- a/大二下/物联网导论/QRCode/encode/QRCode/src/qrcode/QRCode.cpp
+++ b/大二下/物联网导论/QRCode/encode/QRCode/src/qrcode/QRCode.cpp
@@ -485,7 +485,7 @@ string QRCode::EncodeData(void)
 
     res += terminator;
 
-    // Pad 0 to the right of the string to make it lenght multiple of 8
+    // Pad 0 to the right of the string to make it length multiple of 8
     while (strlen(res.c_str()) % 8 != 0)
         res += "0";
 


### PR DESCRIPTION
There is a small typo in 大二下/物联网导论/QRCode/decode/QRCode/src/qrcode/QRCode.cpp, 大二下/物联网导论/QRCode/encode/QRCode/src/qrcode/QRCode.cpp.

Should read `length` rather than `lenght`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md